### PR TITLE
Clear latestEvents

### DIFF
--- a/MicroService-Common/MicroServices.Common/Repository/InMemoryRepository.cs
+++ b/MicroService-Common/MicroServices.Common/Repository/InMemoryRepository.cs
@@ -57,9 +57,12 @@ namespace MicroServices.Common.Repository
             latestEvents.AddRange(eventsToSave);
             if (bus != null)
             {
-                foreach (var latestEvent in latestEvents)
+                for (var index = latestEvents.Count - 1; index >= 0; index--)
                 {
+                    var latestEvent = latestEvents[index];
                     bus.Publish(latestEvent);
+                    // Add any logic here to check if things worked before removing the event from the store.
+                    latestEvents.RemoveAt(index);
                 }
             }
             aggregate.MarkEventsAsCommitted();

--- a/MicroService-Common/MicroServices.Common/Repository/InMemoryRepository.cs
+++ b/MicroService-Common/MicroServices.Common/Repository/InMemoryRepository.cs
@@ -57,12 +57,9 @@ namespace MicroServices.Common.Repository
             latestEvents.AddRange(eventsToSave);
             if (bus != null)
             {
-                for (var index = latestEvents.Count - 1; index >= 0; index--)
+                foreach (Event @event in eventsToSave)
                 {
-                    var latestEvent = latestEvents[index];
-                    bus.Publish(latestEvent);
-                    // Add any logic here to check if things worked before removing the event from the store.
-                    latestEvents.RemoveAt(index);
+                    bus.Publish(@event);
                 }
             }
             aggregate.MarkEventsAsCommitted();


### PR DESCRIPTION
After pushing the events into the bus from the latestEvents, we should clear it out, as currently it keeps pushing the whole Events list again and again, every time you add a new event.